### PR TITLE
fix: support operations without tags

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -22717,13 +22717,15 @@ function collateTags(api) {
   });
   const generatedTagCache = new Set();
   operations.forEach(({ path, operation, operationObject }) => {
-    if (operationObject.tags.length === 0) {
+    var _a;
+    const tags = (_a = operationObject.tags) != null ? _a : [];
+    if (tags.length === 0) {
       tagMap.set(untaggedTag, [
         ...tagMap.get(untaggedTag) || [],
         { path, operation, operationObject }
       ]);
     }
-    operationObject.tags.forEach((tagName) => {
+    tags.forEach((tagName) => {
       let tag;
       if (api.tags) {
         tag = api.tags.find(({ name }) => {

--- a/lib/spaceGenerator.tsx
+++ b/lib/spaceGenerator.tsx
@@ -96,13 +96,14 @@ export function collateTags(api: OpenAPI.Document) {
   const generatedTagCache = new Set<TagObject>();
 
   operations.forEach(({ path, operation, operationObject }) => {
-    if (operationObject.tags.length === 0) {
+    const tags = operationObject.tags ?? [];
+    if (tags.length === 0) {
       tagMap.set(untaggedTag, [
         ...(tagMap.get(untaggedTag) || []),
         { path, operation, operationObject },
       ]);
     }
-    operationObject.tags.forEach((tagName) => {
+    tags.forEach((tagName) => {
       let tag: TagObject;
       if (api.tags) {
         tag = api.tags.find(({ name }) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -110,13 +110,14 @@ function collateTags(api: OpenAPI.Document) {
     }
   );
   operations.forEach(({ path, operation, operationObject }) => {
-    if (operationObject.tags.length === 0) {
+    const tags = operationObject.tags ?? [];
+    if (tags.length === 0) {
       tagMap.set(untaggedTag, [
         ...(tagMap.get(untaggedTag) || []),
         { path, operation, operationObject },
       ]);
     }
-    operationObject.tags.forEach((tagName) => {
+    tags.forEach((tagName) => {
       const tag: TagObject = api.tags.find(({ name }) => {
         return name === tagName;
       });


### PR DESCRIPTION
This fixes a runtime error (undefined dereference) triggered by operations which do not declare tags.