### PR TITLE
Fixed mentions of package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Make sure you have a recent version of Node.js installed.
 In your CLI run
 
 ```sh
-$ npx @gitbook/openapi-autodoc -f ./path/to/my/openapi.yaml
+$ npx @gitbook/openapi -f ./path/to/my/openapi.yaml
 ```
 
 The CLI will generate documentation in your current working directory.
@@ -22,7 +22,7 @@ Space.
 
 ### In a continuous integration environment
 
-You can set up @gitbook/openapi-autodoc in your continuous integration
+You can set up @gitbook/openapi in your continuous integration
 environment to automatically generate documentation from an OpenAPI
 specification in your repository, or one generated earlier in the build process.
 
@@ -38,7 +38,7 @@ solution you use.
    push a commit containing the generated documentation.
 2. Install Node in your CI environment, if it's not already available.
 3. If necessary, generate your openapi spec.
-4. Run `npx @gitbook/openapi-autodoc -f ./path/to/my/openapi.yaml` in the root
+4. Run `npx @gitbook/openapi -f ./path/to/my/openapi.yaml` in the root
    directory of your repository.
 5. If your generated documentation files have changed, commit them and push them
    to the repository. Files to look for are `.gitbook.yaml` and the `docs` folder.


### PR DESCRIPTION
Reading the docs was confusing at first. This should close https://github.com/GitbookIO/openapi-autodoc/issues/3